### PR TITLE
Made the sell sign and the description of the tools translatable

### DIFF
--- a/src/main/java/mytown/entities/signs/SellSign.java
+++ b/src/main/java/mytown/entities/signs/SellSign.java
@@ -15,10 +15,10 @@ import net.minecraft.util.EnumChatFormatting;
 
 public class SellSign extends Sign {
 
-    private static final String TITLE = "Plot Sale";
-    private static final String DESCRIPTION_OWNER = EnumChatFormatting.BLUE + "by ";
-    private static final String DESCRIPTION_PRICE = EnumChatFormatting.GOLD.toString();
-    private static final String DESCRIPTION_RESTRICTED = EnumChatFormatting.RED.toString() + "RESTRICTED";
+    private static final String TITLE = MyTown.instance.LOCAL.getLocalization("mytown.sign.sell.title");
+    private static final String DESCRIPTION_OWNER = MyTown.instance.LOCAL.getLocalization("mytown.sign.sell.description.owner")+" ";
+    private static final String DESCRIPTION_PRICE = MyTown.instance.LOCAL.getLocalization("mytown.sign.sell.description.price");
+    private static final String DESCRIPTION_RESTRICTED = MyTown.instance.LOCAL.getLocalization("mytown.sign.sell.description.restricted");
 
     private int price;
     private boolean restricted;

--- a/src/main/java/mytown/entities/tools/PlotSelectionTool.java
+++ b/src/main/java/mytown/entities/tools/PlotSelectionTool.java
@@ -13,7 +13,6 @@ import mytown.util.MyTownUtils;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.EnumChatFormatting;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
@@ -21,11 +20,11 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
  */
 public class PlotSelectionTool extends Tool {
 
-    private static final String NAME = "Selector"; // TODO: Get localization for it, maybe?
-    private static final String DESCRIPTION_HEADER_1 = EnumChatFormatting.DARK_AQUA + "Select 2 blocks to make a plot.";
-    private static final String DESCRIPTION_HEADER_2 = EnumChatFormatting.DARK_AQUA + "Shift right-click air to change modes.";
-    private static final String DESCRIPTION_NAME = EnumChatFormatting.DARK_AQUA + "Name: ";
-    private static final String DESCRIPTION_MODE = EnumChatFormatting.DARK_AQUA + "Height dependent: ";
+    private static final String NAME = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.selection.name");
+    private static final String DESCRIPTION_HEADER_1 = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.selection.description.header1");
+    private static final String DESCRIPTION_HEADER_2 = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.selection.description.header2");
+    private static final String DESCRIPTION_NAME = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.selection.description.name")+" ";
+    private static final String DESCRIPTION_MODE = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.selection.description.mode")+" ";
 
     private Selection selectionFirst, selectionSecond;
     private String plotName;
@@ -80,7 +79,7 @@ public class PlotSelectionTool extends Tool {
     public void onShiftRightClick() {
         heightDependent = !heightDependent;
         updateDescription();
-        owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode", "heightDependent", heightDependent));
+        owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode", MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.description.mode"), heightDependent));
     }
 
     public void resetSelection(boolean resetBlocks, int delay) {

--- a/src/main/java/mytown/entities/tools/PlotSellTool.java
+++ b/src/main/java/mytown/entities/tools/PlotSellTool.java
@@ -21,11 +21,11 @@ import net.minecraftforge.common.util.ForgeDirection;
  */
 public class PlotSellTool extends Tool {
 
-    private static final String NAME = "Plot Sell";
-    private static final String DESCRIPTION_HEADER_1 = EnumChatFormatting.DARK_AQUA + "Right-click in a plot to place a sell sign.";
-    private static final String DESCRIPTION_HEADER_2 = EnumChatFormatting.DARK_AQUA + "Shift-right-click air to change modes.";
-    private static final String DESCRIPTION_PRICE = EnumChatFormatting.DARK_AQUA + "Price: ";
-    private static final String DESCRIPTION_MODE = EnumChatFormatting.DARK_AQUA + "Restricted to residents: ";
+    private static final String NAME = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.sell.name");
+    private static final String DESCRIPTION_HEADER_1 = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.sell.description.header1");
+    private static final String DESCRIPTION_HEADER_2 = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.sell.description.header2");
+    private static final String DESCRIPTION_PRICE = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.sell.description.price")+" ";
+    private static final String DESCRIPTION_MODE = MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.sell.description.mode")+" ";
 
     private int price;
     private boolean restricted = false;
@@ -64,7 +64,7 @@ public class PlotSellTool extends Tool {
     public void onShiftRightClick() {
         this.restricted = !this.restricted;
         updateDescription();
-        owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode", "Restricted to residents", restricted));
+        owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode", MyTown.instance.LOCAL.getLocalization("mytown.tool.plot.sell.mode"), restricted));
     }
 
     protected boolean hasPermission(Town town, BlockPos bp) {

--- a/src/main/java/mytown/entities/tools/WhitelisterTool.java
+++ b/src/main/java/mytown/entities/tools/WhitelisterTool.java
@@ -17,11 +17,11 @@ import net.minecraft.util.EnumChatFormatting;
  */
 public class WhitelisterTool extends Tool {
 
-    private static final String NAME = "Whitelister";
-    private static final String DESCRIPTION_HEADER_1 = EnumChatFormatting.DARK_AQUA + "Select block for bypassing protection.";
-    private static final String DESCRIPTION_HEADER_2 = EnumChatFormatting.DARK_AQUA + "Shift right-click air to change flag.";
-    private static final String DESCRIPTION_FLAG = EnumChatFormatting.DARK_AQUA + "Flag: ";
-    private static final String DESCRIPTION_FLAG_REMOVAL = EnumChatFormatting.RED + "WHITELIST REMOVAL";
+    private static final String NAME = MyTown.instance.LOCAL.getLocalization("mytown.tool.whitelister.name");
+    private static final String DESCRIPTION_HEADER_1 = MyTown.instance.LOCAL.getLocalization("mytown.tool.whitelister.description.header1");
+    private static final String DESCRIPTION_HEADER_2 = MyTown.instance.LOCAL.getLocalization("mytown.tool.whitelister.description.header2");
+    private static final String DESCRIPTION_FLAG = MyTown.instance.LOCAL.getLocalization("mytown.tool.whitelister.description.flag")+" ";
+    private static final String DESCRIPTION_FLAG_REMOVAL = MyTown.instance.LOCAL.getLocalization("mytown.tool.whitelister.description.removal");
 
     private Resident owner;
     private FlagType flagType = FlagType.ACCESS;
@@ -61,15 +61,24 @@ public class WhitelisterTool extends Tool {
         if(flagType == FlagType.getWhitelistable().get(FlagType.getWhitelistable().size() - 1)) {
             flagType = null;
             updateDescription();
-            owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode", "mode", "WHITELIST REMOVAL"));
+            owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode",
+                    MyTown.instance.LOCAL.getLocalization("mytown.tool.whitelister.mode"),
+                    MyTown.instance.LOCAL.getLocalization("mytown.tool.whitelister.mode.removal")
+            ));
         } else if(flagType == null) {
             flagType = FlagType.getWhitelistable().get(0);
             updateDescription();
-            owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode", "flagType", flagType));
+            owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode",
+                    MyTown.instance.LOCAL.getLocalization("mytown.tool.whitelister.mode.flagType"),
+                    flagType.name
+            ));
         } else {
             flagType = FlagType.getWhitelistable().get(FlagType.getWhitelistable().indexOf(flagType) + 1);
             updateDescription();
-            owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode", "flagType", flagType));
+            owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.notification.tool.mode",
+                    MyTown.instance.LOCAL.getLocalization("mytown.tool.whitelister.mode.flagType"),
+                    flagType.name
+            ));
         }
     }
 

--- a/src/main/java/mytown/entities/tools/WhitelisterTool.java
+++ b/src/main/java/mytown/entities/tools/WhitelisterTool.java
@@ -92,7 +92,7 @@ public class WhitelisterTool extends Tool {
         if(!(town.residentsMap.get(owner).getName().equals("Assistant") || town.residentsMap.get(owner).getName().equals("Mayor"))) {
             Plot plot = town.plotsContainer.get(bp.getDim(), bp.getX(), bp.getY(), bp.getZ());
             if(plot == null || !plot.ownersContainer.contains(owner)) {
-                owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.cmd.err.perm.whitelist"));
+                owner.sendMessage(MyTown.instance.LOCAL.getLocalization("mytown.cmd.err.perm.whitelist.noPermssion"));
                 return false;
             }
         }

--- a/src/main/resources/mytown/localization/en_US.lang
+++ b/src/main/resources/mytown/localization/en_US.lang
@@ -296,6 +296,7 @@ mytown.notification.db.reloaded=&3The database has been reloaded into memory
 mytown.notification.town.ranks.perm.remove=&aThe permission has been successfully &cremoved&a
 mytown.notification.perm.whitelist.start=&3Right-Click a block to change his flag value, depending on what flag you choosed, that flag will be changed for the block you selected.\nShift & Right-Click to change the mode from &9Town&3 to &9Plot&3 or from &9Plot&3 to &9Town&3
 mytown.notification.perm.town.whitelist.already=&3Block whitelist already exists for that flag
+mytown.notification.perm.town.whitelist.added=&aThe blocks was successfully added to whitelist for that flag
 mytown.notification.friends.invitationSent=&aInvitation has been sent
 mytown.notification.friends.gotInvitation=&aYou've got a new friend invite from %s!
 mytown.notification.friends.removed=&aPlayer has been removed from the friends list

--- a/src/main/resources/mytown/localization/en_US.lang
+++ b/src/main/resources/mytown/localization/en_US.lang
@@ -51,6 +51,30 @@ mytown.flag.RESTRICTIONS=&3Gives permission outside player's plots
 mytown.flag.FAKERS=&3Allows fake players to bypass (ex: TCGolems)
 mytown.flag.NEARBY=&3Allows towns to be made near this town.
 
+# Tools
+mytown.tool.plot.sell.name=Plot Sell
+mytown.tool.plot.sell.description.header1=&3Right-click in a plot to place a sell sign.
+mytown.tool.plot.sell.description.header2=&3Shift-right-click air to change modes.
+mytown.tool.plot.sell.description.price=&3Price:
+mytown.tool.plot.sell.description.mode=&3Restricted to residents:
+mytown.tool.plot.sell.mode=Restricted to residents
+
+mytown.tool.plot.selection.name=Selector
+mytown.tool.plot.selection.description.header1=&3Select 2 blocks to make a plot.
+mytown.tool.plot.selection.description.header2=&3Shift right-click air to change modes.
+mytown.tool.plot.selection.description.price=&3Name:
+mytown.tool.plot.selection.description.mode=&3Height dependent:
+mytown.tool.plot.description.mode=Height dependent
+
+mytown.tool.whitelister.name=Whitelister
+mytown.tool.whitelister.description.header1=&3Select block for bypassing protection.
+mytown.tool.whitelister.description.header2=&3Shift right-click air to change flag.
+mytown.tool.whitelister.description.flag=&3Flag:
+mytown.tool.whitelister.description.removal=&cWHITELIST REMOVAL
+mytown.tool.whitelister.mode=mode
+mytown.tool.whitelister.mode.removal=WHITELIST REMOVAL
+mytown.tool.whitelister.mode.flagType=flag type
+
 # /ta config [load|save]
 mytown.cmd.config.load.start=&3Loading config...
 mytown.cmd.config.load.stop=&aConfig loaded

--- a/src/main/resources/mytown/localization/en_US.lang
+++ b/src/main/resources/mytown/localization/en_US.lang
@@ -75,6 +75,12 @@ mytown.tool.whitelister.mode=mode
 mytown.tool.whitelister.mode.removal=WHITELIST REMOVAL
 mytown.tool.whitelister.mode.flagType=flag type
 
+# Sell Sign
+mytown.sign.sell.title=Plot Sale
+mytown.sign.sell.description.owner=&9by
+mytown.sign.sell.description.price=&6
+mytown.sign.sell.description.restricted=&cRESTRICTED
+
 # /ta config [load|save]
 mytown.cmd.config.load.start=&3Loading config...
 mytown.cmd.config.load.stop=&aConfig loaded


### PR DESCRIPTION
I made the tools and sell signs translatable for better understanding of players who doesn't understand English on non-English servers.

I also found two small problems, one incorrect key and one missing message and I fixed them.

Changing the sign translation on active servers will invalidate all signs with the old messages (they will still display the old messages but right-clicking them will do nothing) but It's better than having English messages on non-English servers.

The enum values on the whitelister tools are still in English but it matches the names in the permission commands `/town perm list` and `/town plot perm list` (just like true/false that clearly indicates enabled/disabled with color) so I think it's OK to be in English.