### PR TITLE
Fixes #407 Exception while adding a block to the whitelist

### DIFF
--- a/src/main/java/mytown/entities/flag/FlagType.java
+++ b/src/main/java/mytown/entities/flag/FlagType.java
@@ -163,6 +163,12 @@ public class FlagType<T> implements Comparable<FlagType<T>>{
         return gson.toJson(value, type);
     }
 
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+
     private enum Property {
         IN_TOWN,
         IN_PLOT,


### PR DESCRIPTION
I noticed that the FlagType's `toString()` method is used in many parts of the project but it hadn't overridden the `Object.toString()` yet, this fixes the issue that I reported and an incorrect message when changing the Whitelister tools:
![2015-11-20_12 31 01](https://cloud.githubusercontent.com/assets/3679022/11303694/ee5b7d6c-8f82-11e5-9335-99a9ba624f3c.png)
