### PR TITLE
Fix: IllegalArgumentException: Name and ID cannot both be blank

### DIFF
--- a/src/main/java/mytown/new_datasource/MyTownUniverse.java
+++ b/src/main/java/mytown/new_datasource/MyTownUniverse.java
@@ -229,7 +229,15 @@ public class MyTownUniverse { // TODO Allow migrating between different Datasour
     }
 
     public Resident getOrMakeResident(String username) {
-        GameProfile profile = MinecraftServer.getServer().func_152358_ax().func_152655_a(username);
+        if(username == null || username.isEmpty()) return null;
+        GameProfile profile;
+        try {
+            profile = MinecraftServer.getServer().func_152358_ax().func_152655_a(username);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
         return profile == null ? null : getOrMakeResident(profile.getId(), profile.getName());
     }
 


### PR DESCRIPTION
This will fix an `IllegalArgumentException: Name and ID cannot both be blank` exception when the `username` argument is an empty string and will prevent the server from crashing if the username can't be checked for some reason (in this case a stack trace will be printed on the logs instead of crashing the entire server or player connections)

Fixes #425 