### PR TITLE
Added inventoryUpdate block for item segments

### DIFF
--- a/src/main/java/mytown/protection/json/ProtectionParser.java
+++ b/src/main/java/mytown/protection/json/ProtectionParser.java
@@ -85,7 +85,7 @@ public class ProtectionParser {
             Protection protection = gson.fromJson(reader, Protection.class);
             reader.close();
             return protection;
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             MyTown.instance.LOG.error("Encountered error when parsing protection file: {}", file.getName());
             MyTown.instance.LOG.error(ExceptionUtils.getStackTrace(ex));
             return null;

--- a/src/main/java/mytown/protection/segment/ClientInventoryUpdate.java
+++ b/src/main/java/mytown/protection/segment/ClientInventoryUpdate.java
@@ -1,0 +1,30 @@
+package mytown.protection.segment;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+import java.util.Collections;
+
+public class ClientInventoryUpdate {
+    private byte mode;
+    public ClientInventoryUpdate(int mode) {
+        this.mode = (byte)mode;
+    }
+
+    public int getMode(){
+        return mode;
+    }
+
+    public void send(EntityPlayer player) {
+        if(mode == 1)
+            Collections.fill(player.inventoryContainer.inventoryItemStacks, null);
+        else if(mode == 2) {
+            // Inventory slots: http://hydra-media.cursecdn.com/minecraft.gamepedia.com/8/8c/Items_slot_number.JPG?version=8c2b6c3bebb8855b34f07f232a9e6d6f
+            int inventorySlot = player.inventory.currentItem;
+
+            // Container slots: http://wiki.vg/images/1/13/Inventory-slots.png
+            int containerSlot = inventorySlot < 9? 36 + inventorySlot : inventorySlot;
+            player.inventoryContainer.inventoryItemStacks.set(containerSlot, null);
+        }
+        player.inventoryContainer.detectAndSendChanges();
+    }
+}

--- a/src/main/java/mytown/protection/segment/Segment.java
+++ b/src/main/java/mytown/protection/segment/Segment.java
@@ -220,6 +220,14 @@ public abstract class Segment {
                 jsonUpdate.addProperty("directional", segment.directionalClientUpdate);
                 json.add("clientUpdate", jsonUpdate);
             }
+            if(segment.inventoryUpdate != null) {
+                JsonObject jsonUpdate = new JsonObject();
+                if(segment.inventoryUpdate.getMode() == 2)
+                    jsonUpdate.addProperty("hand", true);
+                else if(segment.inventoryUpdate.getMode() == 1)
+                    jsonUpdate.addProperty("full", true);
+                json.add("inventoryUpdate", jsonUpdate);
+            }
         }
 
         private void serializeTileEntity(SegmentTileEntity segment, JsonObject json, JsonSerializationContext context) {
@@ -376,6 +384,14 @@ public abstract class Segment {
                     segment.directionalClientUpdate = jsonClientUpdate.get("directional").getAsBoolean();
                 }
                 json.remove("clientUpdate");
+            }
+
+            if(json.has("inventoryUpdate")) {
+                JsonObject jsonItemUpdate = json.get("inventoryUpdate").getAsJsonObject();
+                int mode = jsonItemUpdate.get("hand").getAsBoolean()? 2 : jsonItemUpdate.get("full").getAsBoolean()? 1 : 0;
+                if(mode > 0)
+                    segment.inventoryUpdate = new ClientInventoryUpdate(mode);
+                json.remove("inventoryUpdate");
             }
 
             return segment;

--- a/src/main/java/mytown/protection/segment/SegmentItem.java
+++ b/src/main/java/mytown/protection/segment/SegmentItem.java
@@ -24,6 +24,7 @@ public class SegmentItem extends Segment {
     protected final List<ItemType> types = new ArrayList<ItemType>();
     protected boolean isAdjacent = false;
     protected ClientBlockUpdate clientUpdate;
+    protected ClientInventoryUpdate inventoryUpdate;
     protected boolean directionalClientUpdate = false;
 
     public boolean shouldInteract(ItemStack item, Resident res, PlayerInteractEvent.Action action, BlockPos bp, int face) {
@@ -50,6 +51,8 @@ public class SegmentItem extends Segment {
                     ForgeDirection direction = ForgeDirection.getOrientation(face);
                     clientUpdate.send(bp, player, directionalClientUpdate ? direction : ForgeDirection.UNKNOWN);
                 }
+                if(inventoryUpdate != null)
+                    inventoryUpdate.send(player);
                 return false;
             }
         } else {
@@ -59,6 +62,8 @@ public class SegmentItem extends Segment {
                     ForgeDirection direction = ForgeDirection.getOrientation(face);
                     clientUpdate.send(bp, player, directionalClientUpdate ? direction : ForgeDirection.UNKNOWN);
                 }
+                if(inventoryUpdate != null)
+                    inventoryUpdate.send(player);
                 return false;
             }
         }
@@ -87,6 +92,8 @@ public class SegmentItem extends Segment {
                 if(clientUpdate != null) {
                     clientUpdate.send(bp, player);
                 }
+                if(inventoryUpdate != null)
+                    inventoryUpdate.send(player);
                 return false;
             }
         } else {
@@ -95,6 +102,8 @@ public class SegmentItem extends Segment {
                 if(clientUpdate != null) {
                     clientUpdate.send(bp, player);
                 }
+                if(inventoryUpdate != null)
+                    inventoryUpdate.send(player);
                 return false;
             }
         }


### PR DESCRIPTION
This will update the player inventory on client side then the segment denies an action.

For example:
```
    {
      "class": "thaumcraft.common.items.wands.ItemWandCasting",
      "type": "item",
      "actions": [ "RIGHT_CLICK_BLOCK" ],
      "isAdjacent": false,
      "flags": [ "USAGE" ],
      "range": 1,
      "inventoryUpdate": {
        "hand": true
      }
    }
```
If a player right click a thaumcraft table with a wand on a protected zone, the wand would visually disappear, the player would need to click on the empty slot to the wand become visible again. The inventoryUpdate block will update it immediately so the player will see the wand disappear and reappear in the same second.

The block accepts two options: `hand` and `full`, hand updates only the item on hand and full updates the entire inventory.