### PR TITLE
Change: Prevents breaking blocks in area affected by place protection

### DIFF
--- a/src/main/java/mytown/protection/ProtectionHandlers.java
+++ b/src/main/java/mytown/protection/ProtectionHandlers.java
@@ -337,10 +337,24 @@ public class ProtectionHandlers {
             }
         } else {
             Resident res = MyTownUniverse.instance.getOrMakeResident(ev.getPlayer());
-            if (!ProtectionManager.checkBlockBreak(ev.block)) {
-                if(!ProtectionManager.hasPermission(res, FlagType.MODIFY, ev.world.provider.dimensionId, ev.x, ev.y, ev.z)) {
-                    ev.setCanceled(true);
-                    return;
+
+            if (!MyTownUniverse.instance.blocks.contains(ev.world.provider.dimensionId, ev.x >> 4, ev.z >> 4)) {
+                int range = Config.instance.placeProtectionRange.get();
+                Volume breakBox = new Volume(ev.x-range, ev.y-range, ev.z-range, ev.x+range, ev.y+range, ev.z+range);
+
+                if(!ProtectionManager.checkBlockBreak(ev.block)) {
+                    if(!ProtectionManager.hasPermission(res, FlagType.MODIFY, ev.world.provider.dimensionId, breakBox)) {
+                        ev.setCanceled(true);
+                        return;
+                    }
+                }
+
+            } else {
+                if (!ProtectionManager.checkBlockBreak(ev.block)) {
+                    if(!ProtectionManager.hasPermission(res, FlagType.MODIFY, ev.world.provider.dimensionId, ev.x, ev.y, ev.z)) {
+                        ev.setCanceled(true);
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
I thought it was very strange to be able to break a block but restricted to place it back, so I extended the place protection to protect from players break blocks around the town.